### PR TITLE
Adafruit raspberry pi LCD: create custom character method added

### DIFF
--- a/robo4j-hw-rpi/src/main/java/com/robo4j/hw/rpi/i2c/adafruitlcd/AdafruitLcd.java
+++ b/robo4j-hw-rpi/src/main/java/com/robo4j/hw/rpi/i2c/adafruitlcd/AdafruitLcd.java
@@ -193,4 +193,20 @@ public interface AdafruitLcd {
 	 * @throws IOException
 	 */
 	void reset() throws IOException;
+
+	/**
+	 * Fill one of the first 8 CGRAM locations with custom characters. The
+	 * location parameter should be between 0 and 7 and pattern should provide
+	 * an array of 8 bytes containing the pattern. e.g. you can design your
+	 * custom character at <a
+	 * href=http://www.quinapalus.com/hd44780udg.html>http://www.quinapalus.com/hd44780udg.html<a/>.
+	 * To show your custom character obtain the string representation for the
+	 * location e.g. String.format("custom char=%c", 0).
+	 * 
+	 * @param location
+	 *            storage location for this character, between 0 and 7
+	 * @param pattern
+	 *            array of 8 bytes containing the character's pattern
+	 */
+	void createChar(int location, byte[] pattern) throws IOException;
 }

--- a/robo4j-hw-rpi/src/main/java/com/robo4j/hw/rpi/i2c/adafruitlcd/impl/RealLcd.java
+++ b/robo4j-hw-rpi/src/main/java/com/robo4j/hw/rpi/i2c/adafruitlcd/impl/RealLcd.java
@@ -66,7 +66,7 @@ public class RealLcd extends AbstractI2CDevice implements AdafruitLcd {
 	private static final int LCD_DISPLAYCONTROL = 0x08;
 	private static final int LCD_CURSORSHIFT = 0x10;
 	// private static final int LCD_FUNCTIONSET = 0x20;
-	// private static final int LCD_SETCGRAMADDR = 0x40;
+	private static final int LCD_SETCGRAMADDR = 0x40;
 	private static final int LCD_SETDDRAMADDR = 0x80;
 
 	// Flags for display on/off control
@@ -512,5 +512,23 @@ public class RealLcd extends AbstractI2CDevice implements AdafruitLcd {
 	@Override
 	public synchronized void reset() throws IOException {
 		initialize();
+	}
+
+	@Override
+	public void createChar(int location, byte[] pattern) throws IOException {
+		if(location < 0 || location > 7) {
+			throw new IllegalArgumentException("location should be between 0 and 7, value supplied is invalid: " + location);
+		}
+		if(pattern.length != 8) {
+			throw new IllegalArgumentException("pattern length should be 8, array supplied has invalid length: " + pattern.length);
+		}
+		
+		// send ccgram update command
+        location &= 0x7; // only position 0..7 are allowed
+        int command = LCD_SETCGRAMADDR | (location << 3);
+        write(command);
+        
+        // send custom character definition
+        internalWrite(new String(pattern));
 	}
 }

--- a/robo4j-hw-rpi/src/main/java/com/robo4j/hw/rpi/i2c/adafruitlcd/mockup/MockupLcd.java
+++ b/robo4j-hw-rpi/src/main/java/com/robo4j/hw/rpi/i2c/adafruitlcd/mockup/MockupLcd.java
@@ -271,6 +271,16 @@ public class MockupLcd implements AdafruitLcd {
 		// TODO Auto-generated method stub
 
 	}
+
+	@Override
+	public void createChar(int location, byte[] pattern) {
+		if(location < 0 || location > 7) {
+			throw new IllegalArgumentException("location should be between 0 and 7, value supplied is invalid: " + location);
+		}
+		if(pattern.length != 8) {
+			throw new IllegalArgumentException("pattern length should be 8, array supplied has invalid length: " + pattern.length);
+		}
+	}
 }
 
 

--- a/robo4j-units-rpi/src/main/java/com/robo4j/units/rpi/lcd/AdafruitLcdUnit.java
+++ b/robo4j-units-rpi/src/main/java/com/robo4j/units/rpi/lcd/AdafruitLcdUnit.java
@@ -195,4 +195,21 @@ public class AdafruitLcdUnit extends I2CRoboUnit<LcdMessage> {
 		return KNOWN_ATTRIBUTES;
 	}
 
+	/**
+	 * Fill one of the first 8 CGRAM locations with custom characters. The
+	 * location parameter should be between 0 and 7 and pattern should provide
+	 * an array of 8 bytes containing the pattern. e.g. you can design your
+	 * custom character at <a
+	 * href=http://www.quinapalus.com/hd44780udg.html>http://www.quinapalus.com/hd44780udg.html<a/>.
+	 * To show your custom character obtain the string representation for the
+	 * location e.g. String.format("custom char=%c", 0).
+	 * 
+	 * @param location
+	 *            storage location for this character, between 0 and 7
+	 * @param pattern
+	 *            array of 8 bytes containing the character's pattern
+	 */
+	public void createChar(final int location, final byte[] pattern) throws IOException {
+		lcd.createChar(location, pattern);
+	}
 }


### PR DESCRIPTION
Hi, thanks very much for the library, it was fairly simple to get the LCD up and running with it. This PR is because I needed to be able to write custom characters to the screen. I'm not sure if it fits in with the project's design pattern, I could see that perhaps you might want to wrap the character definition in an LcdMessage and process it that way rather than having a separate AdafruitLcdUnit.createChar method. Feel free to re-implement it in a more appropriate way, or let me know what would be better. 